### PR TITLE
chore: move RTSP config to env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Local project temp files
+.tmp/

--- a/config/.env.example
+++ b/config/.env.example
@@ -1,0 +1,6 @@
+# RTSP stream configuration
+RTSP_USER = admin
+RTSP_PASSWORD = change-me
+RTSP_HOST = 192.168.1.100
+RTSP_PORT = 554
+RTSP_PATH = h264Preview_01_main

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,9 +1,16 @@
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+
+BASE_DIR = Path(__file__).resolve().parent
+load_dotenv(BASE_DIR / ".env")
+
 # RTSP / CAMERA
-RTSP_USER = "admin"
-RTSP_PASSWORD = "#YoYoIvan500721"
-RTSP_HOST = "192.168.137.58"
-RTSP_PORT = 554
-RTSP_PATH = "h264Preview_01_main"
+RTSP_USER = os.getenv("RTSP_USER", "admin")
+RTSP_PASSWORD = os.getenv("RTSP_PASSWORD")
+RTSP_HOST = os.getenv("RTSP_HOST")
+RTSP_PORT = os.getenv("RTSP_PORT", "554")
+RTSP_PATH = os.getenv("RTSP_PATH", "h264Preview_01_main")
 
 # VIDEO SETTINGS
 FRAME_WIDTH = 1280


### PR DESCRIPTION
Moves RTSP configuration to a local `.env` file so credentials are no longer stored in source code. Adds `.env.example` for setup reference and updates `.gitignore` for local files.